### PR TITLE
Upgraded package ember-cli-html bars to 1.08

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-cli": "2.4.2",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars": "^1.0.3",
+    "ember-cli-htmlbars": "^1.0.8",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-mocha": "0.10.1",
@@ -43,7 +43,7 @@
     "forms"
   ],
   "dependencies": {
-    "ember-cli-htmlbars": "1.0.3",
+    "ember-cli-htmlbars": "1.0.8",
     "ember-cli-babel": "^5.1.5"
   },
   "ember-addon": {


### PR DESCRIPTION
Upgrades this package to avoid a deprecation message on build if used in Ember 2.8 or higher.