### PR TITLE
Fixing #13

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": ">= ^4.0.0"
+    "node": ">= 4"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Sorry about that.

I *think* this fixes the error.

I confirmed that with yarn version 0.27.5 I am able to run:

```bash
yarn add https://github.com/mwisner/ember-credit-card.git\#feat/npm
```
without any errors.
